### PR TITLE
feat: Support getting rates for multiple currencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `php-currency-exchange-rate` will be documented in this file.
 
+## 1.1.0 - 2025-10-05
+
+### Added
+- Added `getRates()` method to get exchange rates for multiple currencies in a single call
+- New `CurrencyRate` value object to represent exchange rates
+- Extended provider interface with `getRates()` method
+- Added comprehensive tests for new functionality
+
 ## 1.0.1 - 2025-10-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,8 +29,24 @@ $exchangeRate = new ExchangeRate($provider);
 
 // Convert 100 USD to EUR.
 $result = $exchangeRate->convert(100, Currency::USD, Currency::EUR);
+echo $result; // Example output: 85.5
 
-echo $result;
+// Get multiple exchange rates at once
+$rates = $exchangeRate->getRates(Currency::USD, [Currency::EUR, Currency::GBP, Currency::JPY]);
+foreach ($rates as $rate) {
+    echo sprintf(
+        "1 %s = %s %s\n",
+        $rate->source->value,
+        $rate->rate,
+        $rate->target->value
+    );
+}
+/*
+Output example:
+1 USD = 0.85 EUR
+1 USD = 0.73 GBP
+1 USD = 110.25 JPY
+*/
 ```
 
 ## Current Supported Providers
@@ -69,6 +85,28 @@ implement the `convert` method.
             }
 
             return null;
+        }
+
+        public function getRates(Currency $source, array $targets): array
+        {
+            // Write your logic here to get multiple exchange rates at once
+            // Example:
+            $rates = [];
+            foreach ($targets as $target) {
+                if ($source === Currency::USD) {
+                    $rates[] = new CurrencyRate(
+                        source: $source,
+                        target: $target,
+                        rate: match($target) {
+                            Currency::VND => 25000,
+                            Currency::EUR => 0.85,
+                            Currency::GBP => 0.73,
+                            default => 1.0
+                        }
+                    );
+                }
+            }
+            return $rates;
         }
     }
     ```

--- a/src/CurrencyRate.php
+++ b/src/CurrencyRate.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace R94ever\CurrencyExchangeRate;
+
+use R94ever\CurrencyExchangeRate\Enums\Currency;
+
+class CurrencyRate
+{
+    public function __construct(public Currency $source, public Currency $target, public float $rate)
+    {
+        //
+    }
+}

--- a/src/ExchangeRate.php
+++ b/src/ExchangeRate.php
@@ -3,16 +3,26 @@
 namespace R94ever\CurrencyExchangeRate;
 
 use R94ever\CurrencyExchangeRate\Enums\Currency;
-use R94ever\CurrencyExchangeRate\Providers\BaseProvider;
+use R94ever\CurrencyExchangeRate\Providers\ExchangeRateProviderInterface;
 
 class ExchangeRate
 {
-    public function __construct(protected ?BaseProvider $provider = null)
+    public function __construct(protected ?ExchangeRateProviderInterface $provider = null)
     {
         //
     }
 
-    public function useProvider(BaseProvider|string $provider): self
+    /**
+     * Set the exchange rate provider to use.
+     *
+     * You can pass either an instance of `ExchangeRateProviderInterface`
+     * or a string representing the name of a registered provider.
+     *
+     * @param ExchangeRateProviderInterface|string $provider The provider to use.
+     * @return self
+     * @throws ExchangeRateException
+     */
+    public function useProvider(ExchangeRateProviderInterface|string $provider): self
     {
         if (is_string($provider)) {
             $this->provider = ProviderRegistry::make($provider);
@@ -23,29 +33,63 @@ class ExchangeRate
         return $this;
     }
 
-    public function getProvider(): BaseProvider
+    public function getProvider(): ExchangeRateProviderInterface
     {
         return $this->provider;
     }
 
+    /**
+     * Convert an amount from one currency to another.
+     *
+     * @param  float  $amount  The amount to convert.
+     * @param  string|Currency  $from  The source currency.
+     * @param  string|Currency  $to  The target currency.
+     * @return float The converted amount.
+     *
+     * @throws ExchangeRateException If the conversion failed.
+     */
     public function convert(float $amount, string|Currency $from, string|Currency $to): float
     {
-        if (is_string($from)) {
-            $from = Currency::tryFrom(strtoupper($from));
-
-            if (! $from instanceof Currency) {
-                throw ExchangeRateException::invalidSourceCurrency();
-            }
-        }
-
-        if (is_string($to)) {
-            $to = Currency::tryFrom(strtoupper($to));
-
-            if (! $to instanceof Currency) {
-                throw ExchangeRateException::invalidTargetCurrency();
-            }
-        }
+        $from = $this->resolveCurrencyParam($from);
+        $to = $this->resolveCurrencyParam($to);
 
         return $this->provider->convert($amount, $from, $to);
+    }
+
+    /**
+     * Get the exchange rates for a source currency and multiple target currencies.
+     *
+     * @param string|Currency $source The source currency.
+     * @param array<Currency> $targets The target currencies.
+     * @return array<CurrencyRate> The exchange rates
+     *
+     * @throws ExchangeRateException If the request failed.
+     */
+    public function getRates(string|Currency $source, array $targets): array
+    {
+        $source = $this->resolveCurrencyParam($source);
+
+        return $this->provider->getRates($source, $targets);
+    }
+
+    /**
+     * Resolve a currency parameter into a Currency object.
+     *
+     * @param string|Currency $currency The currency parameter to resolve.
+     * @return Currency The resolved currency object.
+     *
+     * @throws ExchangeRateException If the currency parameter is invalid.
+     */
+    public function resolveCurrencyParam(string|Currency $currency): Currency
+    {
+        if ($currency instanceof Currency) {
+            return $currency;
+        }
+
+        if ($currency = Currency::tryFrom(strtoupper($currency))) {
+            return $currency;
+        }
+
+        throw ExchangeRateException::invalidCurrency();
     }
 }

--- a/src/ExchangeRateException.php
+++ b/src/ExchangeRateException.php
@@ -6,14 +6,9 @@ use Exception;
 
 class ExchangeRateException extends Exception
 {
-    public static function invalidSourceCurrency(): self
+    public static function invalidCurrency(): self
     {
-        return new self('Invalid source currency code');
-    }
-
-    public static function invalidTargetCurrency(): self
-    {
-        return new self('Invalid target currency code');
+        return new self('Invalid currency code');
     }
 
     public static function providerNotFound(string $name): self

--- a/src/ProviderRegistry.php
+++ b/src/ProviderRegistry.php
@@ -2,25 +2,26 @@
 
 namespace R94ever\CurrencyExchangeRate;
 
-use R94ever\CurrencyExchangeRate\Providers\BaseProvider;
+use InvalidArgumentException;
+use R94ever\CurrencyExchangeRate\Providers\ExchangeRateProviderInterface;
 
 class ProviderRegistry
 {
     /**
-     * @var array<string, class-string<BaseProvider>>
+     * @var array<string, class-string<ExchangeRateProviderInterface>>
      */
     protected static array $providers = [];
 
     /**
      * Register a new exchange rate provider
      *
-     * @param  class-string<BaseProvider>  $providerClass
+     * @param  class-string<ExchangeRateProviderInterface>  $providerClass
      */
     public static function register(string $name, string $providerClass): void
     {
-        if (! is_subclass_of($providerClass, BaseProvider::class)) {
-            throw new \InvalidArgumentException(
-                'Provider class must extend '.BaseProvider::class
+        if (!is_subclass_of($providerClass, ExchangeRateProviderInterface::class)) {
+            throw new InvalidArgumentException(
+                'Provider class must implement '.ExchangeRateProviderInterface::class
             );
         }
 
@@ -32,7 +33,7 @@ class ProviderRegistry
      *
      * @throws ExchangeRateException
      */
-    public static function make(string $name): BaseProvider
+    public static function make(string $name): ExchangeRateProviderInterface
     {
         $name = strtolower($name);
 
@@ -42,7 +43,7 @@ class ProviderRegistry
 
         $providerClass = static::$providers[$name];
 
-        return new $providerClass;
+        return new $providerClass();
     }
 
     /**
@@ -56,7 +57,7 @@ class ProviderRegistry
     /**
      * Get all registered providers
      *
-     * @return array<string, class-string<BaseProvider>>
+     * @return array<string, class-string<ExchangeRateProviderInterface>>
      */
     public static function getProviders(): array
     {

--- a/src/Providers/BaseProvider.php
+++ b/src/Providers/BaseProvider.php
@@ -4,7 +4,7 @@ namespace R94ever\CurrencyExchangeRate\Providers;
 
 use R94ever\CurrencyExchangeRate\Enums\Currency;
 
-abstract class BaseProvider
+abstract class BaseProvider implements ExchangeRateProviderInterface
 {
     public function __construct()
     {
@@ -12,4 +12,6 @@ abstract class BaseProvider
     }
 
     abstract public function convert(float $amount, Currency $from, Currency $to): ?float;
+
+    abstract public function getRates(Currency $source, array $targets): array;
 }

--- a/src/Providers/ExchangeRateHost.php
+++ b/src/Providers/ExchangeRateHost.php
@@ -2,6 +2,7 @@
 
 namespace R94ever\CurrencyExchangeRate\Providers;
 
+use R94ever\CurrencyExchangeRate\CurrencyRate;
 use R94ever\CurrencyExchangeRate\Enums\Currency;
 use R94ever\CurrencyExchangeRate\ExchangeRateException;
 use R94ever\CurrencyExchangeRate\HttpDrivers\CurlHttpClient;
@@ -57,12 +58,79 @@ class ExchangeRateHost extends BaseProvider implements UseHttpClientInterface
         $responseBody = $response->getBody();
         $isSuccess = $responseBody['success'] ?? false;
 
-        if (! $isSuccess) {
+        if (!$isSuccess) {
             $errorMsg = $responseBody['error']['info'] ?? 'Unknown error';
             $errorCode = $responseBody['error']['code'] ?? 0;
             throw new ExchangeRateException($errorMsg, $errorCode);
         }
 
         return $responseBody['result'] ?? null;
+    }
+
+    /**
+     * Get the exchange rates for a source currency and multiple target currencies.
+     *
+     * @param  Currency  $source  The source currency.
+     * @param  array<Currency>  $targets  The target currencies.
+     * @return array<CurrencyRate>  The exchange rates, or null if the request failed.
+     *
+     * @throws ExchangeRateException If the request failed.
+     */
+    public function getRates(Currency $source, array $targets): array
+    {
+        $currencies = array_map(
+            fn (Currency $currency) => $currency->value,
+            $targets
+        );
+        $currencies = join(',', $currencies);
+
+        $response = $this->getHttpClient()->get(self::BASE_URL.'/live', [
+            'access_key' => $this->accessKey,
+            'source' => $source->value,
+            'currencies' => $currencies,
+        ]);
+
+        $responseBody = $response->getBody();
+        $isSuccess = $responseBody['success'] ?? false;
+
+        if (!$isSuccess) {
+            $errorMsg = $responseBody['error']['info'] ?? 'Unknown error';
+            $errorCode = $responseBody['error']['code'] ?? 0;
+            throw new ExchangeRateException($errorMsg, $errorCode);
+        }
+
+        return $this->normalizeRates($source, $responseBody['quotes']);
+    }
+
+    /**
+     * Normalize the exchange rates from the API response.
+     *
+     * The API response rates are in the format of 'XXXYYY', where
+     * - 'XXX' is the source currency, and
+     * - 'YYY' is the exchange rate.
+     *
+     * This function normalizes the exchange rates by creating a new array of
+     * `CurrencyRate` objects, where each object has the source currency, target
+     * currency, and the exchange rate.
+     *
+     * @param Currency $source The source currency.
+     * @param array<string, float> $ratesFromResponse The exchange rates from the API response.
+     * @return array<CurrencyRate> The normalized exchange rates.
+     */
+    public function normalizeRates(Currency $source, array $ratesFromResponse): array
+    {
+        $normalizedRates = [];
+
+        foreach ($ratesFromResponse as $symbol => $rate) {
+            $parsed = str_split($symbol, 3);
+
+            $normalizedRates[] = new CurrencyRate(
+                source: $source,
+                target: Currency::from(strtoupper($parsed[1])),
+                rate: $rate,
+            );
+        }
+
+        return $normalizedRates;
     }
 }

--- a/src/Providers/ExchangeRateProviderInterface.php
+++ b/src/Providers/ExchangeRateProviderInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace R94ever\CurrencyExchangeRate\Providers;
+
+use R94ever\CurrencyExchangeRate\CurrencyRate;
+use R94ever\CurrencyExchangeRate\Enums\Currency;
+
+interface ExchangeRateProviderInterface
+{
+    /**
+     * Convert an amount from one currency to another.
+     *
+     * @param float $amount The amount to convert.
+     * @param Currency $from The source currency.
+     * @param Currency $to The target currency.
+     * @return float|null The converted amount, or null if the conversion failed.
+     */
+    public function convert(float $amount, Currency $from, Currency $to): ?float;
+
+    /**
+     * Get the exchange rates for a source currency and multiple target currencies.
+     *
+     * @param Currency $source The source currency.
+     * @param array<Currency> $targets The target currencies.
+     * @return array<CurrencyRate> The exchange rates, or null if the request failed.
+     */
+    public function getRates(Currency $source, array $targets): array;
+}

--- a/tests/ExchangeRateTest.php
+++ b/tests/ExchangeRateTest.php
@@ -4,11 +4,12 @@ namespace R94ever\CurrencyExchangeRate\Tests;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use R94ever\CurrencyExchangeRate\CurrencyRate;
 use R94ever\CurrencyExchangeRate\Enums\Currency;
 use R94ever\CurrencyExchangeRate\ExchangeRate;
 use R94ever\CurrencyExchangeRate\ExchangeRateException;
 use R94ever\CurrencyExchangeRate\ProviderRegistry;
-use R94ever\CurrencyExchangeRate\Providers\BaseProvider;
+use R94ever\CurrencyExchangeRate\Providers\ExchangeRateProviderInterface;
 use R94ever\CurrencyExchangeRate\Tests\Stubs\MockProvider;
 
 class ExchangeRateTest extends TestCase
@@ -22,82 +23,38 @@ class ExchangeRateTest extends TestCase
     #[Test]
     public function it_can_convert_using_string_currency_codes()
     {
-        $provider = $this->createMock(BaseProvider::class);
-        $provider->expects($this->once())
-            ->method('convert')
-            ->with(100.0, Currency::USD, Currency::EUR)
-            ->willReturn(85.0);
-
-        $result = (new ExchangeRate($provider))->convert(100.0, 'USD', 'EUR');
-        $this->assertEquals(85.0, $result);
+        $result = (new ExchangeRate())->resolveCurrencyParam('USD');
+        $this->assertSame(Currency::USD, $result);
     }
 
     #[Test]
     public function it_can_convert_using_currency_enums()
     {
-        $provider = $this->createMock(BaseProvider::class);
-        $provider->expects($this->once())
-            ->method('convert')
-            ->with(100.0, Currency::GBP, Currency::JPY)
-            ->willReturn(18250.0);
-
-        $result = (new ExchangeRate($provider))->convert(100.0, Currency::GBP, Currency::JPY);
-        $this->assertEquals(18250.0, $result);
-    }
-
-    #[Test]
-    public function it_can_convert_using_mixed_string_and_enum_currencies()
-    {
-        $provider = $this->createMock(BaseProvider::class);
-        $provider->expects($this->once())
-            ->method('convert')
-            ->with(50.0, Currency::AUD, Currency::SGD)
-            ->willReturn(45.0);
-
-        $result = (new ExchangeRate($provider))->convert(50.0, Currency::AUD, 'SGD');
-        $this->assertEquals(45.0, $result);
+        $result = (new ExchangeRate())->resolveCurrencyParam(Currency::GBP);
+        $this->assertSame(Currency::GBP, $result);
     }
 
     #[Test]
     public function it_handles_case_insensitive_currency_codes()
     {
-        $provider = $this->createMock(BaseProvider::class);
-        $provider->expects($this->once())
-            ->method('convert')
-            ->with(200.0, Currency::CAD, Currency::NZD)
-            ->willReturn(220.0);
-
-        $result = (new ExchangeRate($provider))->convert(200.0, 'cad', 'nzd');
-        $this->assertEquals(220.0, $result);
+        $result = (new ExchangeRate())->resolveCurrencyParam('cad');
+        $this->assertEquals(Currency::CAD, $result);
     }
 
     #[Test]
     public function it_throws_exception_when_source_currency_is_invalid()
     {
-        $provider = $this->createMock(BaseProvider::class);
-
         $this->expectException(ExchangeRateException::class);
-        $this->expectExceptionMessage('Invalid source currency code');
+        $this->expectExceptionMessage('Invalid currency code');
 
-        (new ExchangeRate($provider))->convert(10, 'abc', 'VND');
-    }
-
-    #[Test]
-    public function it_throws_exception_when_target_currency_is_invalid()
-    {
-        $provider = $this->createMock(BaseProvider::class);
-
-        $this->expectException(ExchangeRateException::class);
-        $this->expectExceptionMessage('Invalid target currency code');
-
-        (new ExchangeRate($provider))->convert(10, 'EUR', 'EU1');
+        (new ExchangeRate())->resolveCurrencyParam('abc');
     }
 
     #[Test]
     public function it_can_change_the_provider()
     {
-        $provider1 = $this->createMock(BaseProvider::class);
-        $provider2 = $this->createMock(BaseProvider::class);
+        $provider1 = $this->createMock(ExchangeRateProviderInterface::class);
+        $provider2 = $this->createMock(ExchangeRateProviderInterface::class);
 
         $exchangeRate = new ExchangeRate($provider1);
 
@@ -113,7 +70,7 @@ class ExchangeRateTest extends TestCase
     {
         ProviderRegistry::register('mock', MockProvider::class);
 
-        $exchangeRate = new ExchangeRate;
+        $exchangeRate = new ExchangeRate();
         $exchangeRate->useProvider('mock');
 
         $this->assertInstanceOf(MockProvider::class, $exchangeRate->getProvider());
@@ -122,7 +79,7 @@ class ExchangeRateTest extends TestCase
     #[Test]
     public function it_throws_exception_when_using_unregistered_provider()
     {
-        $exchangeRate = new ExchangeRate;
+        $exchangeRate = new ExchangeRate();
 
         $this->expectException(ExchangeRateException::class);
         $this->expectExceptionMessage("Exchange rate provider 'unregistered' not found");
@@ -134,10 +91,105 @@ class ExchangeRateTest extends TestCase
     {
         ProviderRegistry::register('mock', MockProvider::class);
 
-        $exchangeRate = new ExchangeRate;
+        $exchangeRate = new ExchangeRate();
         $exchangeRate->useProvider('mock');
 
         $result = $exchangeRate->convert(100.0, Currency::USD, Currency::EUR);
         $this->assertEquals(150.0, $result);
+    }
+
+    #[Test]
+    public function it_can_get_rates_with_enum_currencies()
+    {
+        $provider = $this->createMock(ExchangeRateProviderInterface::class);
+        $source = Currency::USD;
+        $targets = [Currency::EUR, Currency::GBP, Currency::JPY];
+
+        $expectedRates = [
+            new CurrencyRate(Currency::USD, Currency::EUR, 0.85),
+            new CurrencyRate(Currency::USD, Currency::GBP, 0.73),
+            new CurrencyRate(Currency::USD, Currency::JPY, 110.25),
+        ];
+
+        $provider->expects($this->once())
+            ->method('getRates')
+            ->with($source, $targets)
+            ->willReturn($expectedRates);
+
+        $exchangeRate = new ExchangeRate($provider);
+        $result = $exchangeRate->getRates($source, $targets);
+
+        $this->assertEquals($expectedRates, $result);
+    }
+
+    #[Test]
+    public function it_can_get_rates_with_string_currencies()
+    {
+        $provider = $this->createMock(ExchangeRateProviderInterface::class);
+        $expectedRates = [
+            new CurrencyRate(Currency::USD, Currency::EUR, 0.85),
+            new CurrencyRate(Currency::USD, Currency::GBP, 0.73),
+        ];
+
+        $provider->expects($this->once())
+            ->method('getRates')
+            ->with(
+                Currency::USD,
+                [Currency::EUR, Currency::GBP]
+            )
+            ->willReturn($expectedRates);
+
+        $exchangeRate = new ExchangeRate($provider);
+        $result = $exchangeRate->getRates('USD', [Currency::EUR, Currency::GBP]);
+
+        $this->assertEquals($expectedRates, $result);
+    }
+
+    #[Test]
+    public function it_throws_exception_when_source_currency_is_invalid_in_get_rates()
+    {
+        $provider = $this->createMock(ExchangeRateProviderInterface::class);
+        $exchangeRate = new ExchangeRate($provider);
+
+        $this->expectException(ExchangeRateException::class);
+        $this->expectExceptionMessage('Invalid currency code');
+
+        $exchangeRate->getRates('INVALID', [Currency::EUR, Currency::GBP]);
+    }
+
+    #[Test]
+    public function it_passes_provider_exceptions_through_in_get_rates()
+    {
+        $provider = $this->createMock(ExchangeRateProviderInterface::class);
+        $errorMessage = 'API Error';
+
+        $provider->expects($this->once())
+            ->method('getRates')
+            ->willThrowException(new ExchangeRateException($errorMessage));
+
+        $exchangeRate = new ExchangeRate($provider);
+
+        $this->expectException(ExchangeRateException::class);
+        $this->expectExceptionMessage($errorMessage);
+
+        $exchangeRate->getRates(Currency::USD, [Currency::EUR, Currency::GBP]);
+    }
+
+    #[Test]
+    public function it_works_with_custom_provider_for_get_rates()
+    {
+        ProviderRegistry::register('mock', MockProvider::class);
+
+        $exchangeRate = new ExchangeRate();
+        $exchangeRate->useProvider('mock');
+
+        $result = $exchangeRate->getRates(Currency::USD, [Currency::EUR, Currency::GBP]);
+
+        $this->assertIsArray($result);
+        foreach ($result as $rate) {
+            $this->assertInstanceOf(CurrencyRate::class, $rate);
+            $this->assertEquals(Currency::USD, $rate->source);
+            $this->assertContains($rate->target, [Currency::EUR, Currency::GBP]);
+        }
     }
 }

--- a/tests/Stubs/MockProvider.php
+++ b/tests/Stubs/MockProvider.php
@@ -2,6 +2,7 @@
 
 namespace R94ever\CurrencyExchangeRate\Tests\Stubs;
 
+use R94ever\CurrencyExchangeRate\CurrencyRate;
 use R94ever\CurrencyExchangeRate\Enums\Currency;
 use R94ever\CurrencyExchangeRate\Providers\BaseProvider;
 
@@ -12,5 +13,13 @@ class MockProvider extends BaseProvider
     public function convert(float $amount, Currency $from, Currency $to): ?float
     {
         return $amount * $this->rate;
+    }
+
+    public function getRates(Currency $source, array $targets): array
+    {
+        return array_map(
+            fn (Currency $target) => new CurrencyRate($source, $target, $this->rate),
+            $targets
+        );
     }
 }


### PR DESCRIPTION
This commit introduces the ability to fetch multiple exchange rates in a single call.

- Adds a `getRates()` method to the `ExchangeRate` class and `ExchangeRateProviderInterface`.
- Introduces a new `CurrencyRate` value object to represent exchange rates.
- Implements the `getRates()` method in the `ExchangeRateHost` provider.
- Adds comprehensive tests for the new functionality.
- Updates the `README.md` and `CHANGELOG.md` to reflect the changes.